### PR TITLE
feat(HealthBar): display health bar on top of enemies

### DIFF
--- a/Assets/Implementation/Prefabs.meta
+++ b/Assets/Implementation/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 409d556268b784d04b03a45727171c54
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Implementation/Prefabs/UI.meta
+++ b/Assets/Implementation/Prefabs/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3eb89edb55e04745b06183b8c4fe5cb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Implementation/Prefabs/UI/HealthBar.prefab
+++ b/Assets/Implementation/Prefabs/UI/HealthBar.prefab
@@ -1,0 +1,98 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8730612403662211868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8730612403662211867}
+  - component: {fileID: 499237404369236599}
+  - component: {fileID: 2525581507303871585}
+  m_Layer: 5
+  m_Name: HealthBar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8730612403662211867
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8730612403662211868}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &499237404369236599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8730612403662211868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 11400000, guid: d693d4079b0f0489284e50579d6d5679, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: e0a34839daa754975aa60118d50dce9f, type: 3}
+  m_SortingOrder: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+--- !u!1931382933 &2525581507303871585
+UIRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8730612403662211868}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0

--- a/Assets/Implementation/Prefabs/UI/HealthBar.prefab.meta
+++ b/Assets/Implementation/Prefabs/UI/HealthBar.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ea46a08837b3412995228e886c7d694
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Implementation/Prefabs/UI/HealthBar.uxml
+++ b/Assets/Implementation/Prefabs/UI/HealthBar.uxml
@@ -1,0 +1,4 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/Template/UIToolkit/Game/CompetitiveActionStyle.uss?fileID=7433441132597879392&amp;guid=25077356dd9bf4548b2c9e74070831b9&amp;type=3#CompetitiveActionStyle" />
+    <ui:ProgressBar value="100" title="100" language-direction="LTR" usage-hints="None" style="-unity-background-image-tint-color: rgb(255, 255, 255); color: rgb(0, 0, 0); -unity-text-outline-width: -52px; width: 150px; justify-content: center; align-self: auto; align-content: auto; align-items: auto; flex-direction: column; position: absolute; left: auto;" />
+</ui:UXML>

--- a/Assets/Implementation/Prefabs/UI/HealthBar.uxml.meta
+++ b/Assets/Implementation/Prefabs/UI/HealthBar.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: e0a34839daa754975aa60118d50dce9f
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Implementation/Scripts.meta
+++ b/Assets/Implementation/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9404471c27e4d479ab8b2a9fb922b10b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Implementation/Scripts/AttachPlayerVisualsSystem.cs
+++ b/Assets/Implementation/Scripts/AttachPlayerVisualsSystem.cs
@@ -1,0 +1,30 @@
+using Unity.Entities;
+
+namespace Unity.Template.CompetitiveActionMultiplayer.Implementation
+{
+    [WorldSystemFilter(WorldSystemFilterFlags.ClientSimulation | WorldSystemFilterFlags.ThinClientSimulation)]
+    public partial struct AttachPlayerVisualsSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<BeginSimulationEntityCommandBufferSystem.Singleton>();
+        }
+
+        public void OnUpdate(ref SystemState state)
+        {
+            var ecb = SystemAPI.GetSingletonRW<BeginSimulationEntityCommandBufferSystem.Singleton>()
+                .ValueRW.CreateCommandBuffer(state.WorldUnmanaged);
+
+            foreach (var (character, entity) in SystemAPI
+                         .Query<FirstPersonCharacterSocketHolderComponent>()
+                         .WithNone<HealthBarProxy>()
+                         .WithEntityAccess())
+            {
+                ecb.AddComponent(character.HealthBarSocketEntity, new HealthBarProxy
+                {
+                    PlayerEntity = entity
+                });
+            }
+        }
+    }
+}

--- a/Assets/Implementation/Scripts/AttachPlayerVisualsSystem.cs.meta
+++ b/Assets/Implementation/Scripts/AttachPlayerVisualsSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c2823d5273524412abb26de59e479b79
+timeCreated: 1751240679

--- a/Assets/Implementation/Scripts/Character.meta
+++ b/Assets/Implementation/Scripts/Character.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aaece85fc84147ae9bf5de5f8b0c078a
+timeCreated: 1751227400

--- a/Assets/Implementation/Scripts/FirstPersonCharacterSocketAuthoring.cs
+++ b/Assets/Implementation/Scripts/FirstPersonCharacterSocketAuthoring.cs
@@ -1,0 +1,24 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace Unity.Template.CompetitiveActionMultiplayer.Implementation
+{
+    [DisallowMultipleComponent]
+    public class FirstPersonCharacterSocketAuthoring : MonoBehaviour
+    {
+        public GameObject HealthBarSocket;
+        
+        public class Baker : Baker<FirstPersonCharacterSocketAuthoring>
+        {
+            public override void Bake(FirstPersonCharacterSocketAuthoring authoring)
+            {
+                var entity = GetEntity(TransformUsageFlags.Renderable | TransformUsageFlags.WorldSpace);
+
+                AddComponent(entity, new FirstPersonCharacterSocketHolderComponent
+                {
+                    HealthBarSocketEntity = GetEntity(authoring.HealthBarSocket, TransformUsageFlags.Renderable),
+                });
+            }
+        }
+    }
+}

--- a/Assets/Implementation/Scripts/FirstPersonCharacterSocketAuthoring.cs.meta
+++ b/Assets/Implementation/Scripts/FirstPersonCharacterSocketAuthoring.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 90bf91887b9f4a95abd8b7ac72feda01
+timeCreated: 1751227423

--- a/Assets/Implementation/Scripts/FirstPersonCharacterSocketHolderComponent.cs
+++ b/Assets/Implementation/Scripts/FirstPersonCharacterSocketHolderComponent.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+using Unity.NetCode;
+
+namespace Unity.Template.CompetitiveActionMultiplayer.Implementation
+{
+    [GhostComponent]
+    public struct FirstPersonCharacterSocketHolderComponent : IComponentData
+    {
+        public Entity HealthBarSocketEntity;
+    }
+}

--- a/Assets/Implementation/Scripts/FirstPersonCharacterSocketHolderComponent.cs.meta
+++ b/Assets/Implementation/Scripts/FirstPersonCharacterSocketHolderComponent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1b83963e37d44ac383d2654ecf510e3c
+timeCreated: 1751227412

--- a/Assets/Implementation/Scripts/HUDResources.cs
+++ b/Assets/Implementation/Scripts/HUDResources.cs
@@ -1,0 +1,11 @@
+using Unity.Entities;
+using UnityEngine;
+
+namespace Unity.Template.CompetitiveActionMultiplayer.Implementation
+{
+    public struct HUDResources : IComponentData
+    {
+        public UnityObjectRef<GameObject> HealthBarUIPrefab;
+        public UnityObjectRef<GameObject> DeathScreenUIPrefab;
+    }
+}

--- a/Assets/Implementation/Scripts/HUDResources.cs.meta
+++ b/Assets/Implementation/Scripts/HUDResources.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9c435ab64998475e841ba286b5937de9
+timeCreated: 1751209221

--- a/Assets/Implementation/Scripts/HealthBar.meta
+++ b/Assets/Implementation/Scripts/HealthBar.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 373be20422ecc4cb8b50deca74bb02a9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Implementation/Scripts/HealthBarUpdateSystem.cs
+++ b/Assets/Implementation/Scripts/HealthBarUpdateSystem.cs
@@ -1,0 +1,138 @@
+using System.Globalization;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Unity.Template.CompetitiveActionMultiplayer.Implementation
+{
+    public struct HealthBarProxy : IComponentData
+    {
+        public Entity PlayerEntity;
+    }
+
+    public class HealthBarProxyCleanup : ICleanupComponentData
+    {
+        public UIDocument UIDocumentComponent;
+    }
+    
+
+    /// <summary>
+    /// This class creates and update the position of the players name on each character currently playing.
+    /// </summary>
+    [UpdateInGroup(typeof(PresentationSystemGroup))]
+    [UpdateAfter(typeof(ProjectilePredictionUpdateGroup))]
+    [WorldSystemFilter(WorldSystemFilterFlags.ClientSimulation)]
+    public partial class HealthBarUpdateSystem : SystemBase
+    {
+        protected override void OnCreate()
+        {
+            //TODO: dont use this
+            RequireForUpdate<GameManagedResources>();
+        }
+
+        protected override void OnUpdate()
+        {
+            SpawnHealthBar();
+            UpdateHealthBarValue();
+            UpdateHealthBarPosition();
+            CleanUpHealthBar();
+        }
+
+        void SpawnHealthBar()
+        {
+            EntityCommandBuffer ecb = SystemAPI.GetSingletonRW<BeginSimulationEntityCommandBufferSystem.Singleton>().ValueRW.CreateCommandBuffer(World.Unmanaged);
+            foreach (var (healthBarProxy, entity) in SystemAPI.Query<RefRO<HealthBarProxy>>()
+                         .WithNone<HealthBarProxyCleanup>().WithEntityAccess())
+            {
+                //Obtain health
+                Entity playerEntity = healthBarProxy.ValueRO.PlayerEntity;
+
+                var health = -1f;
+                if (EntityManager.HasComponent<Health>(playerEntity))
+                    health = EntityManager.GetComponentData<Health>(playerEntity).CurrentHealth;
+
+                var healthBarContained = GameManager.Instance.PlayerNameContainer; //TODO: check what is this
+
+                //TODO: dont use this singleton, create a new one
+                GameObject healthBarInstance =
+                    Object.Instantiate(SystemAPI.GetSingleton<GameManagedResources>().HealthBarPrefab.Value,
+                        healthBarContained.transform, true);
+                
+                //TODO: protect against null ref
+                var uiDocumentComponent = healthBarInstance.GetComponent<UIDocument>();
+                ProgressBar progressBar = uiDocumentComponent.rootVisualElement.Q<ProgressBar>();
+                progressBar.value = health;
+                progressBar.title = health.ToString(CultureInfo.InvariantCulture);
+
+                ecb.AddComponent(entity, new HealthBarProxyCleanup { UIDocumentComponent = uiDocumentComponent });
+            }
+        }
+        
+        void UpdateHealthBarValue()
+                {
+                    ComponentLookup<Health> healthLookup = SystemAPI.GetComponentLookup<Health>(true);
+                    var ecb = SystemAPI.GetSingletonRW<EndSimulationEntityCommandBufferSystem.Singleton>().ValueRW.CreateCommandBuffer(World.Unmanaged);
+
+                    foreach (var (proxy, cleanup, entity) in SystemAPI.Query<RefRO<HealthBarProxy>, HealthBarProxyCleanup>().WithEntityAccess())
+                    {
+                        var playerEntity = proxy.ValueRO.PlayerEntity;
+                        if (!healthLookup.HasComponent(playerEntity))
+                            continue;
+
+                        var health = healthLookup[playerEntity];
+                        
+                        if (health.CurrentHealth <= 0f)
+                        {
+                            // Remove the HealthBarProxy to trigger cleanup
+                            ecb.RemoveComponent<HealthBarProxy>(entity);
+                            continue;
+                        }
+                        
+                        var healthRatio = health.CurrentHealth / health.MaxHealth;
+
+                        var progressBar = cleanup.UIDocumentComponent.rootVisualElement.Q<ProgressBar>();
+                        if (progressBar != null)
+                        {
+                            progressBar.value = healthRatio;
+                            progressBar.title = health.CurrentHealth.ToString("F0");
+                        }
+                    }
+                }
+        
+
+        void CleanUpHealthBar()
+        {
+            EntityCommandBuffer ecb = SystemAPI.GetSingletonRW<EndSimulationEntityCommandBufferSystem.Singleton>().ValueRW.CreateCommandBuffer(World.Unmanaged);
+            foreach (var (cleanup, entity) in SystemAPI.Query<HealthBarProxyCleanup>().WithNone<HealthBarProxy>().WithEntityAccess())
+            {
+                if (cleanup.UIDocumentComponent)
+                {
+                    cleanup.UIDocumentComponent.rootVisualElement.Clear();
+                    Object.Destroy(cleanup.UIDocumentComponent.gameObject);
+                }
+                ecb.RemoveComponent<HealthBarProxyCleanup>(entity);
+            }
+        }
+
+        void UpdateHealthBarPosition()
+        {
+            if (SystemAPI.HasSingleton<MainCamera>())
+            {
+                Entity mainCameraEntity = SystemAPI.GetSingletonEntity<MainCamera>();
+                float3 mainCameraPosition = SystemAPI.GetComponent<LocalToWorld>(mainCameraEntity).Position;
+
+                foreach (var (ltw, cleanup) in SystemAPI.Query<RefRO<LocalToWorld>, HealthBarProxyCleanup>())
+                {
+                    if (cleanup.UIDocumentComponent)
+                    {
+                        var ltwPosition = ltw.ValueRO.Position;
+                        var lookAtDirection = ltwPosition - mainCameraPosition;
+                        cleanup.UIDocumentComponent.transform.SetPositionAndRotation(ltwPosition, Quaternion.LookRotation(lookAtDirection));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Implementation/Scripts/HealthBarUpdateSystem.cs.meta
+++ b/Assets/Implementation/Scripts/HealthBarUpdateSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a3e1bdfb49154eb8997e73640f3b9923
+timeCreated: 1751208512

--- a/Assets/Implementation/Scripts/Unity.Template.CompetitiveActionMultiplayer.asmref
+++ b/Assets/Implementation/Scripts/Unity.Template.CompetitiveActionMultiplayer.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:7d1852719152341449d469f7cfd3f5bd"
+}

--- a/Assets/Implementation/Scripts/Unity.Template.CompetitiveActionMultiplayer.asmref.meta
+++ b/Assets/Implementation/Scripts/Unity.Template.CompetitiveActionMultiplayer.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6b2333901ad6d4cf38a4fed02d682090
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Template/Prefabs/GameResources.prefab
+++ b/Assets/Template/Prefabs/GameResources.prefab
@@ -44,7 +44,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0f2cd7643347b0f4dbf1cd3003951cd1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  JoinTimeout: 6
   DespawnTicks: 16
   PolledEventsTicks: 16
   RespawnTimeSeconds: 4
@@ -59,6 +58,7 @@ MonoBehaviour:
   - {fileID: 9058671491380490423, guid: b57eb5e59fe483041bcc4dee19f60dbc, type: 3}
   SpectatorPrefab: {fileID: 10482797864367398, guid: 6f4378ce200172f42bc501e84a3a7220, type: 3}
   NameTagPrefab: {fileID: 8730612403662211868, guid: ef87bfdfd51e45f4f83acb4dd63871fe, type: 3}
+  HealthBarPrefab: {fileID: 8730612403662211868, guid: 9ea46a08837b3412995228e886c7d694, type: 3}
   SpawnPointBlockRadius: 1
   MachineGunBulletHitVfx: {fileID: 5735981394477805925, guid: 6ce8060434497e6429ed57f804fc5215, type: 3}
   ShotgunBulletHitVfx: {fileID: 5735981394477805925, guid: ee9a55247cf3a1249b7a416fc5dcf30a, type: 3}

--- a/Assets/Template/Prefabs/Ghosts/Character.prefab
+++ b/Assets/Template/Prefabs/Ghosts/Character.prefab
@@ -286,6 +286,7 @@ GameObject:
   - component: {fileID: 8494599271149049586}
   - component: {fileID: 3304333005748147725}
   - component: {fileID: 2302360045351484791}
+  - component: {fileID: 6235139134527279408}
   m_Layer: 7
   m_Name: Character
   m_TagString: Untagged
@@ -309,6 +310,7 @@ Transform:
   - {fileID: 1863874101226951233}
   - {fileID: 6401532902016766949}
   - {fileID: 397833574}
+  - {fileID: 8805698319118261973}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2674214978767437844
@@ -496,6 +498,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c96ea617348cecb4cb1aeaaa86158a38, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &6235139134527279408
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555240849038293811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 90bf91887b9f4a95abd8b7ac72feda01, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  HealthBarSocket: {fileID: 5792725298555199670}
 --- !u!1 &3463604651959167738
 GameObject:
   m_ObjectHideFlags: 0
@@ -669,6 +684,37 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5792725298555199670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8805698319118261973}
+  m_Layer: 7
+  m_Name: HealthBarSocket
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8805698319118261973
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5792725298555199670}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.701, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1555240849038293810}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6371560197096954920
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Template/Scripts/Gameplay/GameResources/GameResourcesAuthoring.cs
+++ b/Assets/Template/Scripts/Gameplay/GameResources/GameResourcesAuthoring.cs
@@ -29,6 +29,7 @@ namespace Unity.Template.CompetitiveActionMultiplayer
         [Header("Other Prefabs")]
         public GameObject SpectatorPrefab;
         public GameObject NameTagPrefab;
+        public GameObject HealthBarPrefab;
 
         [Tooltip("Prevent player spawning if another player is within this radius!")]
         public float SpawnPointBlockRadius = 1f;
@@ -75,6 +76,7 @@ namespace Unity.Template.CompetitiveActionMultiplayer
                     AddComponent(entity, new GameManagedResources
                     {
                         NameTagPrefab = authoring.NameTagPrefab,
+                        HealthBarPrefab = authoring.HealthBarPrefab,
                     });
 
                     //The order in this array has to follow the VfxType enum order so the correct vfx is spawned
@@ -119,6 +121,7 @@ namespace Unity.Template.CompetitiveActionMultiplayer
     public struct GameManagedResources : IComponentData
     {
         public UnityObjectRef<GameObject> NameTagPrefab;
+        public UnityObjectRef<GameObject> HealthBarPrefab;
     }
 
     public struct GameResourcesWeapon : IBufferElementData


### PR DESCRIPTION
First implementation of a health bar

- Created UIDocument
- `FirstPersonCharacterSocketAuthoring`: Bakes the HealthBarSocket entity for the player prefab
- `AttachPlayerVisualsSystem`: attaches a proxy entity in to a player once it spawns
- `HealthBarUpdateSystem`: Updates the position of the ui, destroys de ui when the player dies, updates the UI with the `Health GhostField`

## TODO
- Split HealthBarUpdateSystem in to different systems to keep single responsibility
- Add predicted visual feedback from on player hit to avoid latency visual artefacts
- Do not spawn a health bar on the head of self player